### PR TITLE
fix to method for implicit temp diff

### DIFF
--- a/src/ansys/units/_constants.py
+++ b/src/ansys/units/_constants.py
@@ -1,0 +1,7 @@
+# quantity "types"
+class _QuantityType:
+    composite = "Composite"
+    derived = "Derived"
+    no_type = "NoType"
+    temperature = "Temperature"
+    temperature_difference = "Temperature Difference"

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 
 import ansys.units as q
+from ansys.units._constants import _QuantityType
 from ansys.units.units import parse_temperature_units
 
 
@@ -122,7 +123,10 @@ class Quantity(float):
         str | None
             Units of temperature difference.
         """
-        if self.type in ["Temperature", "Temperature Difference"]:
+        if self.type in [
+            _QuantityType.temperature,
+            _QuantityType.temperature_difference,
+        ]:
             return "delta_K"
 
     @property
@@ -183,8 +187,8 @@ class Quantity(float):
 
         new_type = None
 
-        if self.type == "Temperature Difference":
-            new_type = "Temperature Difference"
+        if self.type == _QuantityType.temperature_difference:
+            new_type = _QuantityType.temperature_difference
             to_units = Quantity._fix_these_temperature_units(
                 to_units, ignore_exponent=True
             )
@@ -244,11 +248,12 @@ class Quantity(float):
             result = Quantity(value=new_si_value, units=new_units)
             # HACK
             convert_to_temp_difference = (
-                "Temperature" == result.type
-                and __value.type in ("Temperature", "Temperature Difference")
+                _QuantityType.temperature == result.type
+                and __value.type
+                in (_QuantityType.temperature, _QuantityType.temperature_difference)
             )
             if convert_to_temp_difference:
-                result._type = "Temperature Difference"
+                result._type = _QuantityType.temperature_difference
             return result
 
         if isinstance(__value, (float, int)):
@@ -317,7 +322,7 @@ class Quantity(float):
 
     def _fix_temperature_units(self):
         # HACK
-        ignore_exponent = self.type == "Temperature Difference"
+        ignore_exponent = self.type == _QuantityType.temperature_difference
         self._unit = Quantity._fix_these_temperature_units(self._unit, ignore_exponent)
         self._si_units = Quantity._fix_these_temperature_units(
             self._si_units, ignore_exponent, ("K",)
@@ -328,9 +333,8 @@ class Quantity(float):
         # Temperature Difference information. Return
         # Temperature Difference if it's involved else None
         # such that the caller figures it out in the usual way
-        temperature_difference = "Temperature Difference"
-        if "Temperature Difference" in (self.type, other.type):
-            return "Temperature Difference"
+        if _QuantityType.temperature_difference in (self.type, other.type):
+            return _QuantityType.temperature_difference
 
 
 class QuantityError(ValueError):

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Optional, Tuple
 
 import ansys.units as q
 from ansys.units._constants import _QuantityType
@@ -122,7 +122,7 @@ class Quantity(float):
         if not isinstance(__value, Quantity) and (not self.is_dimensionless):
             raise QuantityError.INCOMPATIBLE_VALUE(__value)
 
-    def _temp_precheck(self) -> str | None:
+    def _temp_precheck(self) -> Optional[str]:
         """Validate units for temperature differences.
 
         Returns

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -179,6 +179,11 @@ class Quantity(float):
         if not isinstance(to_units, str):
             raise TypeError("`to_units` should be a `str` type.")
 
+        if self.type == "Temperature Difference":
+            to_units = Quantity._fix_these_temperature_units(
+                to_units, ignore_exponent=True
+            )
+
         # Retrieve all SI required SI data and perform conversion
         _, si_multiplier, si_offset = self._units_table.si_data(to_units)
         new_value = (self.si_value / si_multiplier) - si_offset

--- a/src/ansys/units/tables.py
+++ b/src/ansys/units/tables.py
@@ -2,6 +2,7 @@ import os
 
 import yaml
 
+from ansys.units._constants import _QuantityType
 from ansys.units.quantity import Quantity, QuantityError  # noqa: F401
 from ansys.units.units import parse_temperature_units
 
@@ -286,13 +287,13 @@ class UnitsTable(object):
         """
 
         if units == "":
-            return "No Type"
+            return _QuantityType.no_type
 
         if units in self.fundamental_units:
             return self.fundamental_units[units]["type"]
 
         if units in self.derived_units:
-            return "Derived"
+            return _QuantityType.derived
 
         # HACK
         temperature_units_to_search = ("K", "C", "F", "R")
@@ -303,7 +304,7 @@ class UnitsTable(object):
                 units_to_search=temperature_units_to_search,
             )
             if any(is_diff for (_, is_diff) in terms):
-                return "Temperature Difference"
-            return "Temperature"
+                return _QuantityType.temperature_difference
+            return _QuantityType.temperature
 
-        return "Composite"
+        return _QuantityType.composite

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -284,6 +284,44 @@ def test_to_33():
         convert = v.to(0)
 
 
+def test_temperature_to():
+    t1 = q.Quantity(273.15, "K")
+    t1C = t1.to("C")
+    assert t1C.type == "Temperature"
+    assert t1C.value == 0.0
+    assert t1C.units == "C"
+
+
+def test_temperature_difference_to_with_explicit_delta():
+    t1 = q.Quantity(1.0, "K")
+    t2 = q.Quantity(2.0, "K")
+    td1 = t2 - t1
+    td1C = td1.to("delta_C")
+    assert td1C.type == "Temperature Difference"
+    assert td1C.value == 1.0
+    assert td1C.units == "delta_C"
+    td2 = t1 - t2
+    td2C = td2.to("delta_C")
+    assert td2C.type == "Temperature Difference"
+    assert td2C.value == -1.0
+    assert td2C.units == "delta_C"
+
+
+def test_temperature_difference_to_with_implicit_delta():
+    t1 = q.Quantity(1.0, "K")
+    t2 = q.Quantity(2.0, "K")
+    td1 = t2 - t1
+    td1C = td1.to("C")
+    assert td1C.type == "Temperature Difference"
+    assert td1C.value == 1.0
+    assert td1C.units == "delta_C"
+    td2 = t1 - t2
+    td2C = td2.to("C")
+    assert td2C.type == "Temperature Difference"
+    assert td2C.value == -1.0
+    assert td2C.units == "delta_C"
+
+
 def test_repr():
     v = q.Quantity(1.0, "m")
     assert v.__repr__() == 'Quantity (1.0, "m")'

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -322,6 +322,21 @@ def test_temperature_difference_to_with_implicit_delta():
     assert td2C.units == "delta_C"
 
 
+def test_complex_temperature_difference_to():
+    t1 = q.Quantity(1.0, "K")
+    t2 = q.Quantity(2.0, "K")
+    m = q.Quantity(1.0, "kg")
+    result = m * (t2 - t1)
+    resultC1 = result.to("kg C")
+    assert resultC1.type == "Temperature Difference"
+    assert resultC1.value == 1.0
+    assert resultC1.units == "kg delta_C"
+    resultC2 = result.to("kg delta_C")
+    assert resultC2.type == "Temperature Difference"
+    assert resultC2.value == 1.0
+    assert resultC2.units == "kg delta_C"
+
+
 def test_repr():
     v = q.Quantity(1.0, "m")
     assert v.__repr__() == 'Quantity (1.0, "m")'


### PR DESCRIPTION
This is one more bug fix. In fact it's number 7 here: https://github.com/ansys/pyunits/issues/25.

This one is subtler and more debatable than the others, We have added two tests (see test_quantity.py). The already-passing test is where we explicitly convert to e.g., `delta_C`. But if we have a temperature-difference-like quantity, it is also not correct to convert that quality away. 

Note that none of this is rigorous but it is the best we can do within the current framework. The issue is that we can label a whole quantity as either Temperature or Temperature Difference if it contains a component of that type. But what if it contains both? We are unable to handle that situation correctly due to this coarse-grained labelling. 

EDIT:
Added more tests -  the "complex" to test. Along with code changes.