### PR TITLE
Some alignment with PyFluent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,9 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+env*/
+venv*/
+ENV*/
 
 # Spyder project settings
 .spyderproject
@@ -151,6 +154,9 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# VS Code
+.vscode
 
 # PyCharm
 #  JetBrains specific template is maintainted in a separate JetBrains.gitignore that can

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -j auto
+SPHINXOPTS    = -j auto -w build_errors.txt -N -q
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = _build

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -9,6 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=source
 set BUILDDIR=_build
+set SPHINXOPTS=-j auto -w build_errors.txt -N -q
 
 if "%1" == "" goto help
 if "%1" == "clean" goto clean
@@ -31,7 +32,9 @@ goto end
 
 :clean
 rmdir /s /q %BUILDDIR% > /NUL 2>&1
+rmdir /s /q %SOURCEDIR%\examples > /NUL 2>&1
 for /d /r %SOURCEDIR% %%d in (_autosummary) do @if exist "%%d" rmdir /s /q "%%d"
+del build_errors.txt > /NUL 2>&1
 goto end
 
 :help


### PR DESCRIPTION
- Ignore .vscode settings area
- Sphinx builds should use warnings as errors